### PR TITLE
Add ppc64le arch (WIP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.dapper
 .docker-env.*
 dist/

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,11 +1,18 @@
 FROM ubuntu:16.04
 # FROM arm=armhf/ubuntu:16.04
+# FROM ppc64le/ubuntu:16.04
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 
-RUN apt-get update && apt-get install -y build-essential wget curl iproute2 && \
-    apt-get build-dep -y strongswan
+RUN echo \
+  "deb-src http://ports.ubuntu.com/ubuntu-ports/ xenial-updates main restricted" \
+  >> /etc/apt/sources.list
+
+RUN apt-get -q update && \
+    apt-get -qy install build-essential wget curl iproute2 && \
+    apt-get build-dep -y strongswan && \
+    rm -rf /var/lib/apt/lists/*
 
 ARG VERSION=5.5.1
 ENV VERSION=${VERSION} PACKAGE="-rancher-1-1"

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,6 +1,6 @@
-FROM ubuntu:16.04
-# FROM arm=armhf/ubuntu:16.04
-# FROM ppc64le/ubuntu:16.04
+FROM zambon/ubuntu-multi:16.04
+# FROM ubuntu:16.04
+# FROM arm=arm32v7/ubuntu:16.04 ppc64le=ppc64le/ubuntu:16.04
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}

--- a/scripts/package
+++ b/scripts/package
@@ -10,5 +10,8 @@ ARCH=${ARCH:?"ARCH not set"}
 rm -rf ./dist/artifacts
 mkdir -p ./dist/artifacts/
 
-tar -cvzf ./dist/artifacts/strongswan-v${VERSION}${PACKAGE}-${ARCH}.tar.gz $(find /usr/local \! -type d)
-ls -lah ./dist/artifacts/strongswan-v${VERSION}${PACKAGE}-${ARCH}.tar.gz
+ARTIFACT_PATH="./dist/artifacts/strongswan-v${VERSION}${PACKAGE}-${ARCH}.tar.gz"
+
+tar -cvzf "$ARTIFACT_PATH" $(find /usr/local \! -type d)
+shasum -a 256 | awk '{print $1}' > "$ARTIFACT_PATH.sha256"
+ls -lah "$ARTIFACT_PATH"*

--- a/scripts/package
+++ b/scripts/package
@@ -13,5 +13,5 @@ mkdir -p ./dist/artifacts/
 ARTIFACT_PATH="./dist/artifacts/strongswan-v${VERSION}${PACKAGE}-${ARCH}.tar.gz"
 
 tar -cvzf "$ARTIFACT_PATH" $(find /usr/local \! -type d)
-shasum -a 256 | awk '{print $1}' > "$ARTIFACT_PATH.sha256"
+shasum -a 256  "$ARTIFACT_PATH" | awk '{print $1}' > "$ARTIFACT_PATH.sha256"
 ls -lah "$ARTIFACT_PATH"*

--- a/scripts/package
+++ b/scripts/package
@@ -6,11 +6,9 @@ cd $(dirname $0)/..
 VERSION=${VERSION:?"VERSION not set"}
 PACKAGE=${PACKAGE:?"PACKAGE not set"}
 ARCH=${ARCH:?"ARCH not set"}
-SUFFIX=""
-[ "${ARCH}" != "amd64" ] && SUFFIX="_${ARCH}"
 
 rm -rf ./dist/artifacts
 mkdir -p ./dist/artifacts/
 
-tar -cvzf ./dist/artifacts/strongswan-v${VERSION}${PACKAGE}${SUFFIX}.tar.gz $(find /usr/local \! -type d)
-ls -lah ./dist/artifacts/strongswan-v${VERSION}${PACKAGE}${SUFFIX}.tar.gz
+tar -cvzf ./dist/artifacts/strongswan-v${VERSION}${PACKAGE}-${ARCH}.tar.gz $(find /usr/local \! -type d)
+ls -lah ./dist/artifacts/strongswan-v${VERSION}${PACKAGE}-${ARCH}.tar.gz


### PR DESCRIPTION
* Adds missing APT source repository.
* Makes `${ARCH}` part of the artifact name, so that it can be easily scripted with `$(uname -m)`.